### PR TITLE
Handle loss of camera connection gracefully

### DIFF
--- a/axis-ptz-controller/axis_ptz_controller.py
+++ b/axis-ptz-controller/axis_ptz_controller.py
@@ -808,15 +808,21 @@ class AxisPtzController(BaseMQTTPubSub):
             logging.debug(
                 f"Commanding pan and tilt rate indexes: {pan_rate_index}, {tilt_rate_index}"
             )
-            self.camera_control.continuous_move(
-                pan_rate_index,
-                tilt_rate_index,
-                0.0,
-            )
-            if not self.do_capture:
-                logging.info(f"Starting image capture of object: {self.object_id}")
-                self.do_capture = True
-                self.capture_time = time()
+            if self.camera_control.is_connected():
+                self.camera_control.continuous_move(
+                    pan_rate_index,
+                    tilt_rate_index,
+                    0.0,
+                )
+                if not self.do_capture:
+                    logging.info(f"Starting image capture of object: {self.object_id}")
+                    self.do_capture = True
+                    self.capture_time = time()
+
+            else:
+                # Intialize the object id to point the camera at the
+                # object directly once the camera reconnects
+                self.object_id = "NA"
 
         # Log camera pointing using MQTT
         if self.log_to_mqtt:

--- a/axis-ptz-controller/camera_control.py
+++ b/axis-ptz-controller/camera_control.py
@@ -88,3 +88,17 @@ class CameraControl(vapix_control.CameraControl):
 
         """
         return self._camera_command({"focus": focus})
+
+    def is_connected(self) -> bool:
+        """
+        Operation to test camera connection.
+
+        Returns:
+            Bool indicating connection, or not
+
+        """
+        resp = self._camera_command({"query": "position"})
+        if resp.status_code == 200:
+            return True
+        else:
+            return False


### PR DESCRIPTION
If connection to the camera is lost, the controller will command the camera to point at the aircraft directly, rather than command the camera to move continuously, until the camera reconnects.